### PR TITLE
Fix prepareJsonResponse with empty $data

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -93,7 +93,7 @@ class Statement
 
         $this->result = json_decode($data);
         foreach (self::JSON_RESPONSE_POSSIBLE_KEYS as $possibleKey) {
-            if (property_exists($this->result, $possibleKey)) {
+            if (is_object($this->result) && property_exists($this->result, $possibleKey)) {
                 $this->{$possibleKey} = $this->result->{$possibleKey};
             }
         }


### PR DESCRIPTION
Fast fix for warning

> PHP Warning:  First parameter must either be an object or the name of an existing class